### PR TITLE
Make Bun package version configurable via BUN_VERSION and add checksum step; bump default to 1.3.9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       bun_version:
-        description: 'Bun version to build (e.g., 1.3.6)'
+        description: 'Bun version to build (e.g., 1.3.9)'
         required: true
-        default: '1.3.6'
+        default: '1.3.9'
 
 permissions:
   contents: write
@@ -92,11 +92,13 @@ jobs:
 
               # Build bun-bootstrap
               cd /workspace/aports/testing/bun-bootstrap
-              su builder -c "abuild -r"
+              su builder -c "BUN_VERSION=${{ github.event.inputs.bun_version }} abuild checksum"
+              su builder -c "BUN_VERSION=${{ github.event.inputs.bun_version }} abuild -r"
 
               # Build bun
               cd /workspace/aports/testing/bun
-              su builder -c "abuild -r"
+              su builder -c "BUN_VERSION=${{ github.event.inputs.bun_version }} abuild checksum"
+              su builder -c "BUN_VERSION=${{ github.event.inputs.bun_version }} abuild -r"
 
               # Collect packages to output directory
               mkdir -p /workspace/output

--- a/aports/testing/bun-bootstrap/APKBUILD
+++ b/aports/testing/bun-bootstrap/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Cristian Falcone <cristianfalcone@gmail.com>
 pkgname=bun-bootstrap
-pkgver="${BUN_VERSION}"
+pkgver="${BUN_VERSION:-1.3.6}"
 pkgrel=0
 pkgdesc="Bootstrap binary for building Bun from source"
 url="https://bun.sh"

--- a/aports/testing/bun-bootstrap/APKBUILD
+++ b/aports/testing/bun-bootstrap/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Cristian Falcone <cristianfalcone@gmail.com>
 pkgname=bun-bootstrap
-pkgver=1.3.6
+pkgver="${BUN_VERSION}"
 pkgrel=0
 pkgdesc="Bootstrap binary for building Bun from source"
 url="https://bun.sh"

--- a/aports/testing/bun/APKBUILD
+++ b/aports/testing/bun/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Cristian Falcone <cristianfalcone@gmail.com>
 pkgname=bun
-pkgver=1.3.6
+pkgver="${BUN_VERSION}"
 pkgrel=0
 pkgdesc="Incredibly fast JavaScript runtime, bundler, test runner and package manager"
 url="https://bun.sh"


### PR DESCRIPTION
### Motivation

- Make the Alpine package builds parameterizable so different Bun releases can be built without editing APKBUILD files by using an environment variable. 
- Ensure `abuild` generates correct checksums for the chosen Bun release instead of relying on hardcoded sums. 
- Update the workflow default Bun version to a newer release (`1.3.9`).

### Description

- Changed the workflow input default and description for `bun_version` from `1.3.6` to `1.3.9` in `.github/workflows/build.yml`. 
- Made `pkgver` dynamic in `aports/testing/bun-bootstrap/APKBUILD` and `aports/testing/bun/APKBUILD` by setting `pkgver="${BUN_VERSION}"` so the builds pick up the provided `BUN_VERSION`. 
- Added `abuild checksum` invocations and pass `BUN_VERSION=${{ github.event.inputs.bun_version }}` into the `su builder -c` calls before running `abuild -r` for both `bun-bootstrap` and `bun` so source checksums are regenerated for the selected version. 

### Testing

- No automated tests were executed as part of this PR; the existing GitHub Actions workflow `Build Alpine Packages` will run CI to build the packages for `x86_64` and `aarch64` when the workflow is triggered.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab2e2e6028832987fd762258f6892e)